### PR TITLE
Fixed case of content-type header in nginx config

### DIFF
--- a/Tutorials/vagrant/self-hosted-vagrant-boxes-with-versioning.md
+++ b/Tutorials/vagrant/self-hosted-vagrant-boxes-with-versioning.md
@@ -802,12 +802,12 @@ server {
 
     # Serve json files with content type header application/json
     location ~ \.json$ {
-        add_header Content-type application/json;
+        add_header Content-Type application/json;
     }
 
     # Serve box files with content type application/octet-stream
     location ~ \.box$ {
-        add_header Content-type application/octet-stream;
+        add_header Content-Type application/octet-stream;
     }
 
     # Deny access to document root and the vagrant folder


### PR DESCRIPTION
http\* urls pointing to metadata files failed due to vagrant doing an case-sensitive check for the content-type header to be application/json to identify if the url points to a metadata file.

See: https://github.com/mitchellh/vagrant/blob/v1.6.3/lib/vagrant/action/builtin/box_add.rb#L488

---

Thank you so much for this great tutorial @hollodotme, my own vagrant cloud is now up and running!
